### PR TITLE
Fix python_path variable 

### DIFF
--- a/kria-dashboard.sh
+++ b/kria-dashboard.sh
@@ -25,7 +25,7 @@
 
 
 ip=$(ip -4 addr show eth0 | grep -oE "inet ([0-9]{1,3}[\.]){3}[0-9]{1,3}" | cut -d ' ' -f2)
-python_path=$(python3 -m site | grep packages |grep usr | sed 's/,//g' | sed 's/ //g'| sed 's/^.//;s/.$//')
+python_path=$(python3 -m site | grep packages |grep usr | head -n 1 | sed 's/,//g' | sed 's/ //g'| sed 's/^.//;s/.$//')
 
 if [ -z $ip ]; then
      echo "Cant find IP addr, please call /usr/bin/kria-dashboard.sh after assigning IP addr"


### PR DESCRIPTION
There can be multiple lines from python3 -m site command and that will break the python_path variable. Fix it by only considering the first hit of path.