### PR TITLE
Fix: multiple python packages directory ambiguity

### DIFF
--- a/kria-dashboard.sh
+++ b/kria-dashboard.sh
@@ -25,7 +25,15 @@
 
 
 ip=$(ip -4 addr show eth0 | grep -oE "inet ([0-9]{1,3}[\.]){3}[0-9]{1,3}" | cut -d ' ' -f2)
-python_path=$(python3 -m site | grep packages |grep usr | head -n 1 | sed 's/,//g' | sed 's/ //g'| sed 's/^.//;s/.$//')
+python_path=($(python3 -m site | grep packages | grep usr | sed 's/,//g' | sed 's/ //g'| sed 's/^.//;s/.$//'))
+
+for ((i=0;i<${#python_path[@]}; i++)); do
+    if [ -d "${python_path[i]}/kria-dashboard" ];
+    then
+        python_path=${python_path[i]}
+        break
+    fi
+done
 
 if [ -z $ip ]; then
      echo "Cant find IP addr, please call /usr/bin/kria-dashboard.sh after assigning IP addr"
@@ -34,4 +42,3 @@ else
     echo "SOM Dashboard will be running at http://$ip:5006/kria-dashboard"
     bokeh serve --show --allow-websocket-origin=$ip:5006 $python_path/kria-dashboard
 fi
-


### PR DESCRIPTION
When there is another python packages directory other than '/usr/lib/python3/dist-packages/kria-dashboard/' kria-dashboard.sh was not able to find bokeh script. New look-up loop is added to overcome this issue.

As you can see below, when I try to run kria-dashboard it gives an error like below.
```
ubuntu@kria:~/ws$ sudo kria-dashboard
SOM Dashboard will be running at http://10.42.0.80:5006/kria-dashboard
ERROR: Path for Bokeh server application does not exist: /usr/local/lib/python3.10/dist-packages/kria-dashboard
```

So when I look the code in kria-dashboard.sh i see that we are trying to fetch the location dynamically using `python3 -m site` command which is giving this output in my environment
```
sys.path = [
    '/home/ubuntu/ws',
    '/usr/lib/python310.zip',
    '/usr/lib/python3.10',
    '/usr/lib/python3.10/lib-dynload',
    '/home/ubuntu/.local/lib/python3.10/site-packages',
    '/usr/local/lib/python3.10/dist-packages',
    '/usr/lib/python3/dist-packages',
    '/usr/lib/python3.10/dist-packages',
]
USER_BASE: '/home/ubuntu/.local' (exists)
USER_SITE: '/home/ubuntu/.local/lib/python3.10/site-packages' (exists)
ENABLE_USER_SITE: True
```

With the current parsing strategy we have in `kria-dashboard.sh` file, it is using `/usr/local/lib/python3.10/dist-packages` as pythonpath and this is causing the problem.


