### PR TITLE
Workaround the numpy deprecated bool8 failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bokeh==2.4.3
+numpy<2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,8 @@ description: |
 
 grade: stable
 confinement: strict
+architectures:
+  - arm64
 
 package-repositories:
   - type: apt


### PR DESCRIPTION
Hello,

kria-dashboard snap service was failing with the following error message:
```
AttributeError: module 'numpy' has no attribute 'bool8'. Did you mean: 'bool
```

It seems like bool8 from numpy is deprecated after version 2 and in the dependency chain of bokeh it installs the latest numpy which creates this issue for us so I added numpy version restriction into our requirements.txt to keep the version that has `bool8`.

In addition to those I also added `architectures` restriction, since we are installing kria-dashboard snap for arm64 devices. 