### PR TITLE
update requirements.txt to install bokeh 3.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bokeh==2.4.3
+bokeh==3.5.1
 numpy<2


### PR DESCRIPTION
Since we have a compatibility with bokeh 3.5.1 I think it should be ok to update requirements.txt to reflect that as well.