### PR TITLE
snap: echo ip address before starting bokeh server

### DIFF
--- a/kria-dashboard-snap.sh
+++ b/kria-dashboard-snap.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+echo "SOM Dashboard will be running at http://$(hostname -I | cut -d' ' -f1):5006/kria-dashboard"
 $SNAP/bin/bokeh serve --address 0.0.0.0 --allow-websocket-origin=* --show $SNAP/var/opt/kria-dashboard


### PR DESCRIPTION
Echo ip address before starting the server, see example output below:
```
SOM Dashboard will be running at http://10.17.10.185:5006/kria-dashboard
2025-05-02 13:47:15,552 Starting Bokeh server version 3.5.1 (running on Tornado 6.4.2)
2025-05-02 13:47:15,557 Host wildcard '*' will allow connections originating from multiple (or possibly all) hostnames or IPs. Use non-wildcard values to restrict access explicitly
2025-05-02 13:47:15,560 User authentication hooks NOT provided (default user enabled)
2025-05-02 13:47:15,577 Bokeh app running at: http://0.0.0.0:5006/kria-dashboard
2025-05-02 13:47:15,577 Starting Bokeh server with process id: 56937
```
